### PR TITLE
Add error pages

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -162,7 +162,7 @@ def refresh(name, uid):
 @app.errorhandler(Exception)
 def error(e):
     code = 500
-    name = ""
+    name = "Internal Server Error"
     if isinstance(e, HTTPException):
         code = e.code
         name = " " + e.name

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, abort, make_response, redirect
 from flask_socketio import SocketIO, emit, join_room, leave_room, send
+from werkzeug.exceptions import HTTPException
 import os
 import json
 import requests
@@ -158,6 +159,14 @@ def refresh(name, uid):
     }).json()
     return response['access_token']
 
+@app.errorhandler(Exception)
+def error(e):
+    code = 500
+    name = ""
+    if isinstance(e, HTTPException):
+        code = e.code
+        name = " " + e.name
+    return render_template("error.html", host=request.host, errno=str(code), name=name)
 
 def checkjson(name):
     name  = '{}.json'.format(name)

--- a/app/js/error.js
+++ b/app/js/error.js
@@ -1,0 +1,16 @@
+class ErrorPage extends React.Component {
+    constructor() {
+        super();
+        this.state = {};
+    }
+    render () {
+	return (
+	    <TopBar />
+	);
+    }
+}
+
+ReactDOM.render(
+    <ErrorPage />,
+    document.getElementById('error-mount-point')
+);

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -129,3 +129,10 @@ h1, p, h2, h3 {
     color: white;
     text-decoration: none;
 }
+#error-text {
+    margin: auto;
+    position: absolute;
+    top: 40%;
+    left: 50%;
+    color: #ffffff;
+}

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -1,0 +1,10 @@
+{% extends 'head.html' %}
+{% block head %}
+    <title>spotify party - error: {{ errno }}</title>
+{% endblock %}
+
+{% block body %}
+    <div id="error-mount-point"></div>
+    <script src='/static/js/build/error.js'></script>
+    <h3 id="error-text">Error: {{ errno }} {{ name }}</h3>
+{% endblock %}


### PR DESCRIPTION
The style can definitely change, but I have implemented a basic error page. It displays the error number and name. The error number is also in the page title (spotify party - error 404).
Here's a sample error page:
![1591589653](https://user-images.githubusercontent.com/34148527/83992211-775dc080-a91d-11ea-9939-6f65ca8986f1.png)
The error information is put in a Flask template, and I created an `ErrorPage` React class that displays the top bar.